### PR TITLE
Updates usage of @covers annotations in tests.

### DIFF
--- a/tests/Fuel/Validation/AbstractRuleTest.php
+++ b/tests/Fuel/Validation/AbstractRuleTest.php
@@ -18,7 +18,7 @@ require_once(__DIR__.'/../../DummyAbstractRule.php');
  * @package Fuel\Validation
  * @author  Fuel Development Team
  *
- * @covers  Fuel\Validation\AbstractRule
+ * @coversDefaultClass \Fuel\Validation\AbstractRule
  */
 class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 {
@@ -34,8 +34,8 @@ class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass __construct
-	 * @group              Validation
+	 * @covers ::__construct
+	 * @group  Validation
 	 */
 	public function testConstruct()
 	{
@@ -56,8 +56,8 @@ class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getMessage
-	 * @group              Validation
+	 * @covers ::getMessage
+	 * @group  Validation
 	 */
 	public function testDefaultMessage()
 	{
@@ -68,9 +68,9 @@ class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getMessage
-	 * @coversDefaultClass setMessage
-	 * @group              Validation
+	 * @covers ::getMessage
+	 * @covers ::setMessage
+	 * @group  Validation
 	 */
 	public function testGetSetMessage()
 	{
@@ -85,8 +85,8 @@ class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getParameter
-	 * @group              Validation
+	 * @covers ::getParameter
+	 * @group  Validation
 	 */
 	public function testGetParam()
 	{
@@ -96,10 +96,10 @@ class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getParameter
-	 * @coversDefaultClass setParameter
-	 * @dataProvider       paramDataProvider
-	 * @group              Validation
+	 * @covers        ::getParameter
+	 * @covers        ::setParameter
+	 * @dataProvider  paramDataProvider
+	 * @group         Validation
 	 */
 	public function testSetGetParam($param)
 	{
@@ -126,8 +126,8 @@ class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getMessageParameters
-	 * @group              Validation
+	 * @covers ::getMessageParameters
+	 * @group  Validation
 	 */
 	public function testGetDefaultMessageParams()
 	{

--- a/tests/Fuel/Validation/FieldTest.php
+++ b/tests/Fuel/Validation/FieldTest.php
@@ -16,7 +16,7 @@ namespace Fuel\Validation;
  * @package Fuel\Validation
  * @author  Fuel Development Team
  *
- * @covers Fuel\Validation\Field
+ * @coversDefaultClass \Fuel\Validation\Field
  */
 class FieldTest extends \PHPUnit_Framework_TestCase
 {
@@ -32,9 +32,9 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass setName
-	 * @coversDefaultClass getName
-	 * @group              Validation
+	 * @covers ::setName
+	 * @covers ::getName
+	 * @group  Validation
 	 */
 	public function testSetGetName()
 	{
@@ -49,9 +49,9 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getLabel
-	 * @coversDefaultClass setLabel
-	 * @group              Validation
+	 * @covers ::getLabel
+	 * @covers ::setLabel
+	 * @group  Validation
 	 */
 	public function testSetGetLabel()
 	{
@@ -66,9 +66,9 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass addRule
-	 * @coversDefaultClass getRules
-	 * @group              Validation
+	 * @covers ::addRule
+	 * @covers ::getRules
+	 * @group  Validation
 	 */
 	public function testAddGetRules()
 	{
@@ -83,8 +83,8 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getLabel
-	 * @group              Validation
+	 * @covers ::getLabel
+	 * @group  Validation
 	 */
 	public function testGetNullLabel()
 	{
@@ -99,8 +99,8 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass __construct
-	 * @group              Validation
+	 * @covers ::__construct
+	 * @group  Validation
 	 */
 	public function testConstruct()
 	{

--- a/tests/Fuel/Validation/ResultTest.php
+++ b/tests/Fuel/Validation/ResultTest.php
@@ -16,7 +16,7 @@ namespace Fuel\Validation;
  * @package Fuel\Validation
  * @author  Fuel Development Team
  *
- * @covers Fuel\Validation\Result
+ * @coversDefaultClass \Fuel\Validation\Result
  */
 class ResultTest extends \PHPUnit_Framework_TestCase
 {
@@ -32,8 +32,8 @@ class ResultTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass setResult
-	 * @coversDefaultClass isValid
+	 * @covers ::setResult
+	 * @covers ::isValid
 	 * @group              Validation
 	 */
 	public function testSetGetResult()
@@ -46,9 +46,9 @@ class ResultTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getError
-	 * @coversDefaultClass getErrors
-	 * @coversDefaultClass setError
+	 * @covers ::getError
+	 * @covers ::getErrors
+	 * @covers ::setError
 	 * @group              Validation
 	 */
 	public function testSetGetErrors()
@@ -85,7 +85,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getError
+	 * @covers ::getError
 	 * @expectedException  Fuel\Validation\InvalidFieldException
 	 * @group              Validation
 	 */
@@ -95,8 +95,8 @@ class ResultTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getValidated
-	 * @coversDefaultClass setValidated
+	 * @covers ::getValidated
+	 * @covers ::setValidated
 	 * @group              Validation
 	 */
 	public function testSetGetValidated()

--- a/tests/Fuel/Validation/Rule/AbstractRuleTest.php
+++ b/tests/Fuel/Validation/Rule/AbstractRuleTest.php
@@ -20,7 +20,7 @@ abstract class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 {
 
 	/**
-	 * @var AbstractRule
+	 * @var \Fuel\Validation\AbstractRule
 	 */
 	protected $object;
 
@@ -30,9 +30,7 @@ abstract class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	protected $message;
 
 	/**
-	 * @coversDefaultClass __construct
-	 * @coversDefaultClass getMessage
-	 * @group              Validation
+	 * @group  Validation
 	 */
 	public function testGetMessage()
 	{
@@ -43,9 +41,8 @@ abstract class AbstractRuleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass validate
-	 * @dataProvider       validateProvider
-	 * @group              Validation
+	 * @dataProvider validateProvider
+	 * @group        Validation
 	 */
 	public function testValidate()
 	{

--- a/tests/Fuel/Validation/RuleProvider/FromArrayTest.php
+++ b/tests/Fuel/Validation/RuleProvider/FromArrayTest.php
@@ -14,14 +14,14 @@ use Fuel\Validation\Rule\MinLength;
 use Fuel\Validation\Rule\Required;
 
 /**
- * Tests for Simple
+ * Tests for FromArray
  *
  * @package Fuel\Validation\RuleProvider
  * @author  Fuel Development Team
  *
- * @covers Fuel\Validation\RuleProvider\FromArray
+ * @coversDefaultClass \Fuel\Validation\RuleProvider\FromArray
  */
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class FromArrayTest extends \PHPUnit_Framework_TestCase
 {
 
 	/**
@@ -35,10 +35,10 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass populateValidation
-	 * @coversDefaultClass getData
-	 * @expectedException  \InvalidArgumentException
-	 * @group              Validation
+	 * @covers            ::populateValidator
+	 * @covers            ::getData
+	 * @expectedException \InvalidArgumentException
+	 * @group             Validation
 	 */
 	public function testNoData()
 	{
@@ -52,9 +52,9 @@ class SimpleTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass populateValidator
-	 * @coversDefaultClass setData
-	 * @group              Validation
+	 * @covers ::populateValidator
+	 * @covers ::setData
+	 * @group  Validation
 	 */
 	public function testPopulate()
 	{

--- a/tests/Fuel/Validation/ValidatorTest.php
+++ b/tests/Fuel/Validation/ValidatorTest.php
@@ -19,7 +19,7 @@ use Fuel\Validation\Rule\Number;
  * @package Fuel\Validation
  * @author  Fuel Development Team
  *
- * @covers  Fuel\Validation\Validator
+ * @coversDefaultClass \Fuel\Validation\Validator
  */
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -67,9 +67,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getRules
-	 * @coversDefaultClass addField
-	 * @group              Validation
+	 * @covers ::addField
+	 * @group  Validation
 	 */
 	public function testAddField()
 	{
@@ -84,9 +83,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass run
-	 * @coversDefaultClass validateField
-	 * @group              Validation
+	 * @covers ::run
+	 * @covers ::validateField
+	 * @group  Validation
 	 */
 	public function testRun()
 	{
@@ -103,9 +102,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass run
-	 * @coversDefaultClass validateField
-	 * @group              Validation
+	 * @covers ::run
+	 * @covers ::validateField
+	 * @group  Validation
 	 */
 	public function testRunFailure()
 	{
@@ -122,10 +121,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass run
-	 * @coversDefaultClass validateField
-	 * @dataProvider       runMultipleFieldsData
-	 * @group              Validation
+	 * @covers ::      run
+	 * @covers ::      validateField
+	 * @dataProvider runMultipleFieldsData
+	 * @group        Validation
 	 */
 	public function testRunMultipleFields($expected, $data)
 	{
@@ -155,9 +154,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass __call
-	 * @expectedException  Fuel\Validation\InvalidRuleException
-	 * @group              Validation
+	 * @covers ::           __call
+	 * @expectedException \Fuel\Validation\InvalidRuleException
+	 * @group             Validation
 	 */
 	public function testMagicRuleInvalid()
 	{
@@ -165,8 +164,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass __call
-	 * @group              Validation
+	 * @covers ::__call
+	 * @group  Validation
 	 */
 	public function testAddMagicRule()
 	{
@@ -182,8 +181,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass setMessage
-	 * @group              Validation
+	 * @covers ::setMessage
+	 * @group  Validation
 	 */
 	public function testSetMessage()
 	{
@@ -199,9 +198,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass setMessage
-	 * @group              Validation
-	 * @expectedException  LogicException
+	 * @covers ::           setMessage
+	 * @group             Validation
+	 * @expectedException \LogicException
 	 */
 	public function testSetMessageException()
 	{
@@ -209,8 +208,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass __call
-	 * @group              Validation
+	 * @covers ::__call
+	 * @group  Validation
 	 */
 	public function testMagicChain()
 	{
@@ -256,9 +255,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass addField
-	 * @expectedException  InvalidArgumentException
-	 * @group              Validation
+	 * @covers ::           addField
+	 * @expectedException \InvalidArgumentException
+	 * @group             Validation
 	 */
 	public function testAddInvalidField()
 	{
@@ -266,8 +265,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass getFieldRules
-	 * @group              Validation
+	 * @covers ::getFieldRules
+	 * @group  Validation
 	 */
 	public function testGetInvalidFieldRules()
 	{
@@ -278,9 +277,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass addCustomRule
-	 * @coversDefaultClass createRuleInstance
-	 * @group              Validation
+	 * @covers ::addCustomRule
+	 * @covers ::createRuleInstance
+	 * @group  Validation
 	 */
 	public function testAddCustomRule()
 	{
@@ -295,9 +294,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass addCustomRule
-	 * @coversDefaultClass createRuleInstance
-	 * @group              Validation
+	 * @covers ::addCustomRule
+	 * @covers ::createRuleInstance
+	 * @group  Validation
 	 */
 	public function testAddCoreRuleOverride()
 	{
@@ -310,8 +309,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass setMessage
-	 * @group              Validation
+	 * @covers ::setMessage
+	 * @group  Validation
 	 */
 	public function testMessageReplacement()
 	{
@@ -328,10 +327,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass setGlobalMessage
-	 * @coversDefaultClass getGlobalMessage
-	 * @coversDefaultClass removeGlobalMessage
-	 * @group              Validation
+	 * @covers ::setGlobalMessage
+	 * @covers ::getGlobalMessage
+	 * @covers ::removeGlobalMessage
+	 * @group  Validation
 	 */
 	public function testGetSetGlobalMessage()
 	{
@@ -357,9 +356,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @coversDefaultClass setGlobalMessage
-	 * @coversDefaultClass createRuleInstance
-	 * @group              Validation
+	 * @covers ::setGlobalMessage
+	 * @covers ::createRuleInstance
+	 * @group  Validation
 	 */
 	public function testCreateRuleInstanceWithGlobalMessage()
 	{


### PR DESCRIPTION
Removes the use of @coversDefaultClass in place of @covers to ensure they
are used as described by the PHPUnit documentation.

Closes #17
