### PR TITLE
Field rules empty array by default

### DIFF
--- a/src/Fuel/Validation/Field.php
+++ b/src/Fuel/Validation/Field.php
@@ -34,7 +34,7 @@ class Field implements FieldInterface
 	/**
 	 * @var RuleInterface[]
 	 */
-	protected $rules;
+	protected $rules = [];
 
 	public function __construct($name = null, $friendlyName = null)
 	{


### PR DESCRIPTION
When adding a field without rules validation fails as the returned rule value is `null` instead of `array`.
