### PR TITLE
Fixes dockblock of validateProvider

### DIFF
--- a/tests/unit/Rule/DateTest.php
+++ b/tests/unit/Rule/DateTest.php
@@ -46,9 +46,7 @@ class DateTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the email validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/EmailTest.php
+++ b/tests/unit/Rule/EmailTest.php
@@ -32,9 +32,7 @@ class EmailTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the email validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/ExactLengthTest.php
+++ b/tests/unit/Rule/ExactLengthTest.php
@@ -33,9 +33,7 @@ class ExactLengthTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the exact length validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/IpTest.php
+++ b/tests/unit/Rule/IpTest.php
@@ -32,9 +32,7 @@ class IpTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides strings to test and expected results for testValidate
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/MatchFieldTest.php
+++ b/tests/unit/Rule/MatchFieldTest.php
@@ -73,9 +73,7 @@ class MatchFieldTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the email validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/MaxLengthTest.php
+++ b/tests/unit/Rule/MaxLengthTest.php
@@ -33,9 +33,7 @@ class MaxLengthTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the maximum length validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/MinLengthTest.php
+++ b/tests/unit/Rule/MinLengthTest.php
@@ -32,9 +32,7 @@ class MinLengthTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the minimum length validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/NumberTest.php
+++ b/tests/unit/Rule/NumberTest.php
@@ -32,9 +32,7 @@ class NumberTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides strings to test and expected results for testValidate
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/NumericBetweenTest.php
+++ b/tests/unit/Rule/NumericBetweenTest.php
@@ -32,9 +32,7 @@ class NumericBetweenTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides strings to test and expected results for testValidate
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/NumericMaxTest.php
+++ b/tests/unit/Rule/NumericMaxTest.php
@@ -32,9 +32,7 @@ class NumericMaxTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides strings to test and expected results for testValidate
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/NumericMinTest.php
+++ b/tests/unit/Rule/NumericMinTest.php
@@ -32,9 +32,7 @@ class NumericMinTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides strings to test and expected results for testValidate
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/RegexTest.php
+++ b/tests/unit/Rule/RegexTest.php
@@ -32,9 +32,7 @@ class RegexTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides strings to test and expected results for testValidate
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/RequiredTest.php
+++ b/tests/unit/Rule/RequiredTest.php
@@ -47,9 +47,7 @@ class RequiredTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the email validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/TypeTest.php
+++ b/tests/unit/Rule/TypeTest.php
@@ -32,9 +32,7 @@ class TypeTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the email validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/UrlTest.php
+++ b/tests/unit/Rule/UrlTest.php
@@ -32,9 +32,7 @@ class UrlTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides strings to test and expected results for testValidate
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{

--- a/tests/unit/Rule/ValueTest.php
+++ b/tests/unit/Rule/ValueTest.php
@@ -32,9 +32,7 @@ class ValueTest extends AbstractRuleTest
 	}
 
 	/**
-	 * Provides sample data for testing the email validation
-	 *
-	 * @return array
+	 * {@inheritdocs}
 	 */
 	public function validateProvider()
 	{


### PR DESCRIPTION
The `validateProvider` function has a dockblock in parent class. Not needed in child classes. Also most of them were totally wrong (eg. contained description for email test)
