### PR TITLE
For validating arrays and structs

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -287,12 +287,14 @@ class Validator
 	protected function buildMessage(FieldInterface $field, RuleInterface $rule, $value)
 	{
 		// Build an array with all the token values
-		$tokens = array(
-			'name' => $field->getName(),
-			'label' => $field->getLabel(),
-			'value' => $value,
-
-		) + $rule->getMessageParameters();
+		$tokens = array_merge(
+			array(
+				'name' => $field->getName(),
+				'label' => $field->getLabel(),
+				'value' => $value,
+			),
+			$rule->getMessageParameters()
+		);
 
 		return $this->processMessageTokens($tokens, $rule->getMessage());
 	}


### PR DESCRIPTION
To avoid error when $value is array or struct (non-scalar):

"Fuel\Core\PhpErrorException [ Notice ]:
Array to string conversion

fuel/vendor/fuelphp/validation/src/Validator.php @ line 316"

in such custom rule class:
```php
class MyRule extends AbstractRule
{
	private $_value; // in case of error - store value

	public function validate($value, $field = null, $allFields = null)
	{
			...
			// if has error
				...
				$this->_value = $value;
				return false;
			// endif
	}
	...

	public function getMessageParameters()
	{
		return array(
			'value' => print_r($this->_value, 1)
		);
	}
}
```