### PR TITLE
Fix multi value error message bug

### DIFF
--- a/src/Rule/EnumMulti.php
+++ b/src/Rule/EnumMulti.php
@@ -53,7 +53,7 @@ class EnumMulti extends AbstractRule
 	public function getMessageParameters()
 	{
 		return array(
-			'values' => implode('|', $this->getParameter()),
+			'value' => implode('|', $this->getParameter()),
 		);
 	}
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -302,11 +302,11 @@ class Validator implements ValidatableInterface
 	protected function buildMessage(FieldInterface $field, RuleInterface $rule, $value)
 	{
 		// Build an array with all the token values
-		$tokens = array(
+		$tokens = array_merge(array(
 			'name' => $field->getName(),
 			'label' => $field->getLabel(),
 			'value' => $value,
-		) + $rule->getMessageParameters();
+		), $rule->getMessageParameters());
 
 		return $this->processMessageTokens($tokens, $rule->getMessage());
 	}

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -347,7 +347,7 @@ class ValidatorTest extends Test
 	public function testMessageReplacementMultiValue()
 	{
 		$this->object->addField('test', 'My Field')
-			->EnumMulti(['foo', 'bar', 'baz', 'bat'])
+			->enumMulti(['foo', 'bar', 'baz', 'bat'])
 			->setMessage('{label} {name} field is should match `{value}`!');
 
 		$result = $this->object->run(array('test' => ['foo', 'bar', 'wombat']));

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -344,6 +344,20 @@ class ValidatorTest extends Test
 		);
 	}
 
+	public function testMessageReplacementMultiValue()
+	{
+		$this->object->addField('test', 'My Field')
+			->EnumMulti(['foo', 'bar', 'baz', 'bat'])
+			->setMessage('{label} {name} field is should match `{value}`!');
+
+		$result = $this->object->run(array('test' => ['foo', 'bar', 'wombat']));
+
+		$this->assertEquals(
+			'My Field test field is should match `foo|bar|baz|bat`!',
+			$result->getError('test')
+		);
+	}
+
 	public function testGetSetGlobalMessage()
 	{
 		$message = 'Test message';


### PR DESCRIPTION
The following error occurred when I attempted to execute the following code.

### Code

```php
$validator = new Fuel\Validation\Validator();
$validator->addField('foo')->EnumMulti(['bar']);
$validator->run(['foo' => ['foobar']]);
```

### Error

Array to string conversion

### Links

#34