### PR TITLE
fixed deprecated implicitly nullable via default value null

### DIFF
--- a/src/InvalidFieldException.php
+++ b/src/InvalidFieldException.php
@@ -31,7 +31,7 @@ class InvalidFieldException extends InvalidArgumentException
 	 *
 	 * @since 2.0
 	 */
-	public function __construct($message = '', $code = 0, Exception $previous = null)
+	public function __construct($message = '', $code = 0, ?Exception $previous = null)
 	{
 		$error = 'VAL-002: The field ['.$message.'] is not known.';
 

--- a/src/InvalidRuleException.php
+++ b/src/InvalidRuleException.php
@@ -31,7 +31,7 @@ class InvalidRuleException extends InvalidArgumentException
 	 *
 	 * @since 2.0
 	 */
-	public function __construct($message = '', $code = 0, Exception $previous = null)
+	public function __construct($message = '', $code = 0, ?Exception $previous = null)
 	{
 		$error = 'VAL-004: The rule ['.$message.'] is not known.';
 

--- a/src/ValidatableInterface.php
+++ b/src/ValidatableInterface.php
@@ -27,5 +27,5 @@ interface ValidatableInterface
 	 *
 	 * @since 2.0
 	 */
-	public function run($data, ResultInterface $result = null);
+	public function run($data, ?ResultInterface $result = null);
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -179,7 +179,7 @@ class Validator implements ValidatableInterface
 	 *
 	 * @since 2.0
 	 */
-	public function run($data, ResultInterface $result = null)
+	public function run($data, ?ResultInterface $result = null)
 	{
 		if ($result === null)
 		{
@@ -215,7 +215,7 @@ class Validator implements ValidatableInterface
 	 *
 	 * @since 2.0
 	 */
-	public function runField($field, array $data, ResultInterface $result = null)
+	public function runField($field, array $data, ?ResultInterface $result = null)
 	{
 		if ($result === null)
 		{


### PR DESCRIPTION
Four files in five places had deprecated in PHP 8.4 parameter that was implicitly nullable via default value null.

Like this:
public function runField($field, array $data, ResultInterface $result = null)